### PR TITLE
Investigate performance due to strictness

### DIFF
--- a/System/FTDI/Internal.hs
+++ b/System/FTDI/Internal.hs
@@ -6,6 +6,7 @@
            , NoImplicitPrelude
            , PatternGuards
            , ScopedTypeVariables
+           , StrictData
            , UnicodeSyntax
   #-}
 


### PR DESCRIPTION
The goal of this PR is to investigate and observe the effects on performance when using strict fields in datatypes, see [BangPatterns](https://downloads.haskell.org/ghc/latest/docs/html/users_guide/exts/strict.html#bang-patterns-informal) and [StrictData](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/strict.html#strict-by-default-data-types). Specifically focusing on `System.FTDI.Internal` and `System.FTDI.MPSSE`.