### PR TITLE
Export `System.FTDI.Internal`, bump version

### DIFF
--- a/ftdi.cabal
+++ b/ftdi.cabal
@@ -1,5 +1,5 @@
 name:          ftdi
-version:       0.3.0.3
+version:       0.3.0.4
 cabal-version: >=1.10
 build-type:    Simple
 stability:     experimental
@@ -22,8 +22,8 @@ source-repository head
 library
   exposed-modules: System.FTDI
                  , System.FTDI.MPSSE
-  other-modules: System.FTDI.Internal
-               , System.FTDI.Utils
+                 , System.FTDI.Internal
+  other-modules: System.FTDI.Utils
   build-depends: async                >= 2.2   && < 2.3
                , base                 >= 4.5   && < 4.21
                , bytestring           >= 0.10  && < 0.13


### PR DESCRIPTION
I ran into a situation where direct access to internal USB device handles was nice to have. The only thing preventing it was the `System.FTDI.Internal` module being hidden.